### PR TITLE
feat(MD_AST): Implement Markdown AST parsing

### DIFF
--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -5,7 +5,7 @@ on:
 
   push:
     branches:
-      - master
+      - md_ast
 
 permissions:
   contents: write

--- a/.github/workflows/development.yml
+++ b/.github/workflows/development.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/checkout@v2
 
       - name: Run translation
-        uses: mrf0rtuna4/Git-Markdown-AutoTranslator@master
+        uses: mrf0rtuna4/Git-Markdown-AutoTranslator@md_ast
         with:
           LANGS: 'ru, ar, uk, it, ja'
           FILES: 'README.md'

--- a/core/app/localizator.py
+++ b/core/app/localizator.py
@@ -22,6 +22,7 @@
 
 import asyncio
 import os
+import re
 from concurrent.futures import ThreadPoolExecutor
 
 from deep_translator import GoogleTranslator
@@ -65,6 +66,33 @@ class LocalizationManager:
             self.translation_executor, self._translate_sync, text, lang
         )
 
+    def _placeholder_pattern(self):
+        placeholders = [
+            re.escape(placeholder)
+            for placeholders in self.processor.placeholder_map.values()
+            for placeholder, _ in placeholders
+        ]
+        if not placeholders:
+            return None
+        return re.compile(f"({'|'.join(placeholders)})")
+
+    async def translate_markdown_unit(self, text, lang):
+        pattern = self._placeholder_pattern()
+        if pattern is None or not pattern.search(text):
+            return await self.translate_text(text, lang)
+
+        translated_parts = []
+        for part in pattern.split(text):
+            if not part:
+                continue
+            if pattern.fullmatch(part):
+                translated_parts.append(part)
+            elif re.search(r"\w", part):
+                translated_parts.append(await self.translate_text(part, lang))
+            else:
+                translated_parts.append(part)
+        return "".join(translated_parts)
+
     async def translate_text(self, text, lang):
         cache_key = (lang, text)
         cached = self._translation_cache.get(cache_key)
@@ -96,13 +124,9 @@ class LocalizationManager:
                     translations[lang].append("")
                 continue
 
-            is_placeholder_only = all(
-                any(
-                    placeholder in line
-                    for placeholders in self.processor.placeholder_map.values()
-                    for placeholder, _ in placeholders
-                )
-                for _ in line.split()
+            placeholder_pattern = self._placeholder_pattern()
+            is_placeholder_only = bool(
+                placeholder_pattern and placeholder_pattern.fullmatch(line.strip())
             )
 
             if is_placeholder_only:
@@ -110,8 +134,9 @@ class LocalizationManager:
                     translations[lang].append(line)
                 continue
 
-            translation_tasks = [self.translate_text(
-                line, lang) for lang in self.langs]
+            translation_tasks = [
+                self.translate_markdown_unit(line, lang) for lang in self.langs
+            ]
             translated_lines = await asyncio.gather(*translation_tasks)
             for lang, translated_line in zip(self.langs, translated_lines):
                 translations[lang].append(translated_line)

--- a/core/app/logger.py
+++ b/core/app/logger.py
@@ -29,17 +29,17 @@ level = logging.INFO
 logging.basicConfig(level=level, format="[%(levelname)s]: %(message)s")
 
 
-def log_error(message):
+def log_error(message: str):
     logging.error(message)
 
 
-def log_info(message):
+def log_info(message: str):
     logging.info(message)
 
 
-def log_warn(message):
+def log_warn(message: str):
     logging.warning(message)
 
 
-def log_dbg(message):
+def log_dbg(message: str):
     logging.debug(message)

--- a/core/app/processor.py
+++ b/core/app/processor.py
@@ -24,18 +24,53 @@ SOFTWARE.
 
 import re
 import uuid
+from dataclasses import dataclass
 
 from .logger import log_dbg, log_error, log_info
 
-EXCLUDED_ADMONITIONS = ("IMPORTANT", "CAUTION", "TIP")
+EXCLUDED_ADMONITIONS = ("IMPORTANT", "CAUTION", "TIP", "WARNING")
+PROTECTED_PLACEHOLDER = "_MD_PROTECTED"
+
+
+@dataclass(frozen=True)
+class MarkdownRange:
+    start: int
+    end: int
+    kind: str
 
 
 class Processor:
     def __init__(self):
         self.placeholder_map = {
             key: []
-            for key in ("_BL0CK", "_L1NK", "_HTML", "_MD_WDGT", "_NON_TRANSLATE")
+            for key in (
+                "_BL0CK",
+                "_L1NK",
+                "_HTML",
+                "_MD_WDGT",
+                "_NON_TRANSLATE",
+                "_MD_BLOCK_NOTE",
+                PROTECTED_PLACEHOLDER,
+            )
         }
+        self._markdown = self._build_markdown_parser()
+
+    @staticmethod
+    def _build_markdown_parser():
+        try:
+            from markdown_it import MarkdownIt
+        except ImportError:
+            log_dbg(
+                "markdown-it-py is unavailable; using conservative fallback parser")
+            return None
+
+        parser = MarkdownIt("commonmark", {"html": True})
+        for rule in ("table", "strikethrough"):
+            try:
+                parser.enable(rule)
+            except ValueError:
+                log_dbg(f"markdown-it-py rule is unavailable: {rule}")
+        return parser
 
     @staticmethod
     def _generate_placeholder(prefix):
@@ -44,83 +79,287 @@ class Processor:
     def clear_placeholder_map(self):
         self.placeholder_map = {k: [] for k in self.placeholder_map}
 
-    def _sanitize_placeholders(self, text, placeholder_map):
-        patterns = {
-            "_BL0CK": r"```[\s\S]*?```",
-            "_MD_WDGT": r"!\[[^]]*]\([^)]+\)",
-            "_L1NK": r"\[([^]]+)]\(([^)]+)\)",
-            "_HTML": r"<.*?>",
-            "_NON_TRANSLATE": r"\[\[.*?\]\]",
-        }
+    def _store_placeholder(self, key, original, placeholder_map):
+        unique_placeholder = self._generate_placeholder(key)
+        placeholder_map.setdefault(key, []).append(
+            (unique_placeholder, original))
+        log_dbg(f"Created placeholder: {unique_placeholder} for tag: {key}")
+        return unique_placeholder
 
-        lines = text.splitlines()
-        processed_lines = []
-        i = 0
-        while i < len(lines):
-            line = lines[i]
+    @staticmethod
+    def _merge_ranges(ranges):
+        merged = []
+        for current in sorted(ranges, key=lambda item: (item.start, item.end)):
+            if current.start >= current.end:
+                continue
+            if not merged or current.start > merged[-1].end:
+                merged.append(current)
+                continue
+            previous = merged[-1]
+            merged[-1] = MarkdownRange(
+                previous.start,
+                max(previous.end, current.end),
+                f"{previous.kind},{current.kind}",
+            )
+        return merged
+
+    @staticmethod
+    def _frontmatter_range(lines):
+        if not lines or lines[0].strip() not in {"---", "+++"}:
+            return None
+
+        marker = lines[0].strip()
+        for index in range(1, len(lines)):
+            if lines[index].strip() == marker:
+                return MarkdownRange(0, index + 1, "frontmatter")
+        return None
+
+    @staticmethod
+    def _line_starts_mdx_statement(line):
+        stripped = line.strip()
+        return bool(
+            re.match(r"^(import|export)\s+", stripped)
+            or re.match(r"^<[A-Z][\w.:]*(\s|>|/>)", stripped)
+            or re.match(r"^</[A-Z][\w.:]*\s*>", stripped)
+        )
+    
+    @staticmethod
+    def asd():
+        a = 1
+        return bool(a)
+
+    @staticmethod
+    def _admonition_type(line):
+        match = re.match(r"^\s*>\s*\[!([A-Z]+)]", line)
+        return match.group(1) if match else None
+
+    def _fallback_ranges(self, lines):
+        protected = []
+        translatable = []
+        index = 0
+
+        frontmatter = self._frontmatter_range(lines)
+        if frontmatter:
+            protected.append(frontmatter)
+            index = frontmatter.end
+
+        while index < len(lines):
+            line = lines[index]
             stripped = line.strip()
-            admonition_match = re.match(r"^>\s*\[!([A-Z]+)]", stripped)
-            if admonition_match and admonition_match.group(1) in EXCLUDED_ADMONITIONS:
-                block = [line]
-                i += 1
-                while i < len(lines):
-                    next_line = lines[i]
-                    if next_line.strip().startswith(">"):
-                        block.append(next_line)
-                        i += 1
-                        continue
-                    break
 
-                original_block = "\n".join(block)
-                unique_placeholder = self._generate_placeholder(
-                    "_MD_BLOCK_NOTE")
-                placeholder_map.setdefault("_MD_BLOCK_NOTE", []).append(
-                    (unique_placeholder, original_block)
-                )
-                log_dbg(
-                    f"Created block-note placeholder: {unique_placeholder}")
-                processed_lines.append(unique_placeholder)
+            if not stripped:
+                index += 1
                 continue
 
-            processed_lines.append(line)
-            i += 1
+            if re.match(r"^(```|~~~)", stripped):
+                marker = stripped[:3]
+                start = index
+                index += 1
+                while index < len(lines) and not lines[index].strip().startswith(
+                    marker
+                ):
+                    index += 1
+                index = min(index + 1, len(lines))
+                protected.append(MarkdownRange(start, index, "fence"))
+                continue
 
-        text = "\n".join(processed_lines)
+            admonition = self._admonition_type(line)
+            if admonition in EXCLUDED_ADMONITIONS:
+                start = index
+                index += 1
+                while index < len(lines) and lines[index].strip().startswith(">"):
+                    index += 1
+                protected.append(MarkdownRange(start, index, "admonition"))
+                continue
 
-        for key, pattern in patterns.items():
-            matches = re.findall(pattern, text)
-            for match in matches:
-                unique_placeholder = self._generate_placeholder(key)
-                match_str = "".join(match) if isinstance(
-                    match, tuple) else match
-                placeholder_map[key].append((unique_placeholder, match_str))
-                log_dbg(
-                    f"Created placeholder: {unique_placeholder} for tag: {key}")
-                text = text.replace(match_str, unique_placeholder, 1)
-        return text
+            if stripped.startswith("|") and "|" in stripped[1:]:
+                start = index
+                while index < len(lines) and lines[index].strip().startswith("|"):
+                    index += 1
+                protected.append(MarkdownRange(start, index, "table"))
+                continue
+
+            if stripped.startswith("<") and stripped.endswith(">"):
+                start = index
+                index += 1
+                while index < len(lines) and lines[index].strip():
+                    if lines[index].strip().startswith("</"):
+                        index += 1
+                        break
+                    if not lines[index].startswith((" ", "\t", "<")):
+                        break
+                    index += 1
+                protected.append(MarkdownRange(start, index, "html"))
+                continue
+
+            if self._line_starts_mdx_statement(line):
+                protected.append(MarkdownRange(index, index + 1, "mdx"))
+                index += 1
+                continue
+
+            start = index
+            index += 1
+            while index < len(lines) and lines[index].strip():
+                next_line = lines[index]
+                if (
+                    re.match(r"^(```|~~~)", next_line.strip())
+                    or self._admonition_type(next_line) in EXCLUDED_ADMONITIONS
+                    or next_line.strip().startswith("|")
+                    or self._line_starts_mdx_statement(next_line)
+                ):
+                    break
+                index += 1
+            translatable.append(MarkdownRange(start, index, "text"))
+
+        return protected, translatable
+
+    def _markdown_it_ranges(self, text, lines):
+        if self._markdown is None:
+            return self._fallback_ranges(lines)
+
+        protected = []
+        translatable = []
+        tokens = self._markdown.parse(text)
+
+        frontmatter = self._frontmatter_range(lines)
+        if frontmatter:
+            protected.append(frontmatter)
+
+        blockquote_stack = []
+        for token in tokens:
+            token_map = token.map
+            if token.type in {"fence", "code_block", "html_block"} and token_map:
+                protected.append(MarkdownRange(
+                    token_map[0], token_map[1], token.type))
+
+            if token.type == "table_open" and token_map:
+                protected.append(MarkdownRange(
+                    token_map[0], token_map[1], "table"))
+
+            if token.type == "blockquote_open" and token_map:
+                blockquote_stack.append(token_map)
+            elif token.type == "blockquote_close" and blockquote_stack:
+                blockquote_map = blockquote_stack.pop()
+                first_line = (
+                    lines[blockquote_map[0]] if blockquote_map[0] < len(
+                        lines) else ""
+                )
+                if self._admonition_type(first_line) in EXCLUDED_ADMONITIONS:
+                    protected.append(
+                        MarkdownRange(
+                            blockquote_map[0], blockquote_map[1], "admonition"
+                        )
+                    )
+
+            if (
+                token.type in {"paragraph_open",
+                               "heading_open", "list_item_open"}
+                and token_map
+            ):
+                translatable.append(
+                    MarkdownRange(token_map[0], token_map[1], token.type)
+                )
+
+        for index, line in enumerate(lines):
+            if self._line_starts_mdx_statement(line):
+                protected.append(MarkdownRange(index, index + 1, "mdx"))
+
+        return self._merge_ranges(protected), self._merge_ranges(translatable)
+
+    @staticmethod
+    def _range_starts(ranges, index):
+        for current in ranges:
+            if current.start == index:
+                return current
+        return None
+
+    @staticmethod
+    def _is_within_ranges(ranges, index):
+        return any(current.start <= index < current.end for current in ranges)
+
+    def _split_translation_unit(self, unit, max_line_length):
+        if len(unit) <= max_line_length:
+            return [unit]
+
+        parts = []
+        current = []
+        current_len = 0
+        for line in unit.splitlines():
+            projected = current_len + len(line) + (1 if current else 0)
+            if current and projected > max_line_length:
+                parts.append("\n".join(current))
+                current = [line]
+                current_len = len(line)
+            else:
+                current.append(line)
+                current_len = projected
+
+        if current:
+            parts.append("\n".join(current))
+        return parts
+
+    def _decompile_with_ast(self, content, placeholder_map, max_line_length):
+        lines = content.splitlines()
+        protected_ranges, translatable_ranges = self._markdown_it_ranges(
+            content, lines)
+        protected_ranges = self._merge_ranges(protected_ranges)
+        translatable_ranges = self._merge_ranges(
+            range_item
+            for range_item in translatable_ranges
+            if not any(
+                protected.start < range_item.end and range_item.start < protected.end
+                for protected in protected_ranges
+            )
+        )
+
+        output = []
+        index = 0
+        while index < len(lines):
+            protected = self._range_starts(protected_ranges, index)
+            if protected:
+                original = "\n".join(lines[protected.start: protected.end])
+                key = (
+                    "_MD_BLOCK_NOTE"
+                    if "admonition" in protected.kind
+                    else PROTECTED_PLACEHOLDER
+                )
+                output.append(self._store_placeholder(
+                    key, original, placeholder_map))
+                index = protected.end
+                continue
+            translatable = self._range_starts(translatable_ranges, index)
+            if translatable:
+                original = "\n".join(
+                    lines[translatable.start: translatable.end])
+                output.extend(self._split_translation_unit(
+                    original, max_line_length))
+                index = translatable.end
+                continue
+
+            if self._is_within_ranges(
+                protected_ranges, index
+            ) or self._is_within_ranges(translatable_ranges, index):
+                index += 1
+                continue
+
+            output.append(lines[index] if lines[index].strip() else "")
+            index += 1
+
+        return output
 
     @staticmethod
     def _restore_placeholders(text, placeholder_map):
-        for key, mappings in placeholder_map.items():
+        for mappings in placeholder_map.values():
             for ph, original in mappings:
                 text = text.replace(ph, original)
         return text
 
     def decompile_file(self, content, *, file=None, max_line_length=500):
         self.clear_placeholder_map()
-        text = self._sanitize_placeholders(content, self.placeholder_map)
-        lines = []
-        for raw in text.splitlines():
-            if not raw.strip():
-                lines.append("")
-                continue
-            line = raw
-            while len(line) > max_line_length:
-                idx = line[:max_line_length].rfind(" ") or max_line_length
-                lines.append(line[:idx])
-                line = line[idx:].lstrip()
-            lines.append(line)
-        log_info(f"💠 Decompiled {file} into {len(lines)} lines.")
+        lines = self._decompile_with_ast(
+            content, self.placeholder_map, max_line_length)
+        log_info(
+            f"💠 Decompiled {file} into {len(lines)} AST translation units.")
         return lines, self.placeholder_map
 
     def build_file(self, translated_lines, placeholder_map, lang, *, file=None):

--- a/core/app/processor.py
+++ b/core/app/processor.py
@@ -124,11 +124,6 @@ class Processor:
         )
     
     @staticmethod
-    def asd():
-        a = 1
-        return bool(a)
-
-    @staticmethod
     def _admonition_type(line):
         match = re.match(r"^\s*>\s*\[!([A-Z]+)]", line)
         return match.group(1) if match else None
@@ -165,11 +160,8 @@ class Processor:
 
             admonition = self._admonition_type(line)
             if admonition in EXCLUDED_ADMONITIONS:
-                start = index
+                protected.append(MarkdownRange(index, index + 1, "admonition"))
                 index += 1
-                while index < len(lines) and lines[index].strip().startswith(">"):
-                    index += 1
-                protected.append(MarkdownRange(start, index, "admonition"))
                 continue
 
             if stripped.startswith("|") and "|" in stripped[1:]:
@@ -247,7 +239,7 @@ class Processor:
                 if self._admonition_type(first_line) in EXCLUDED_ADMONITIONS:
                     protected.append(
                         MarkdownRange(
-                            blockquote_map[0], blockquote_map[1], "admonition"
+                            blockquote_map[0], blockquote_map[0] + 1, "admonition"
                         )
                     )
 
@@ -277,6 +269,47 @@ class Processor:
     def _is_within_ranges(ranges, index):
         return any(current.start <= index < current.end for current in ranges)
 
+    @staticmethod
+    def _subtract_protected_ranges(translatable_ranges, protected_ranges):
+        safe_ranges = []
+        for translatable in translatable_ranges:
+            segments = [(translatable.start, translatable.end)]
+            for protected in protected_ranges:
+                next_segments = []
+                for start, end in segments:
+                    if protected.end <= start or end <= protected.start:
+                        next_segments.append((start, end))
+                        continue
+                    if start < protected.start:
+                        next_segments.append((start, protected.start))
+                    if protected.end < end:
+                        next_segments.append((protected.end, end))
+                segments = next_segments
+
+            safe_ranges.extend(
+                MarkdownRange(start, end, translatable.kind)
+                for start, end in segments
+                if start < end
+            )
+
+        return safe_ranges
+
+    def _protect_inline_markdown(self, unit, placeholder_map):
+        protected = re.sub(
+            r"`[^`\n]+`",
+            lambda match: self._store_placeholder(
+                "_NON_TRANSLATE", match.group(0), placeholder_map
+            ),
+            unit,
+        )
+        return re.sub(
+            r"(?<=\]\()([^\s)]+)",
+            lambda match: self._store_placeholder(
+                "_L1NK", match.group(0), placeholder_map
+            ),
+            protected,
+        )
+
     def _split_translation_unit(self, unit, max_line_length):
         if len(unit) <= max_line_length:
             return [unit]
@@ -304,12 +337,7 @@ class Processor:
             content, lines)
         protected_ranges = self._merge_ranges(protected_ranges)
         translatable_ranges = self._merge_ranges(
-            range_item
-            for range_item in translatable_ranges
-            if not any(
-                protected.start < range_item.end and range_item.start < protected.end
-                for protected in protected_ranges
-            )
+            self._subtract_protected_ranges(translatable_ranges, protected_ranges)
         )
 
         output = []
@@ -317,7 +345,7 @@ class Processor:
         while index < len(lines):
             protected = self._range_starts(protected_ranges, index)
             if protected:
-                original = "\n".join(lines[protected.start: protected.end])
+                original = "\n".join(lines[protected.start : protected.end])
                 key = (
                     "_MD_BLOCK_NOTE"
                     if "admonition" in protected.kind
@@ -329,10 +357,13 @@ class Processor:
                 continue
             translatable = self._range_starts(translatable_ranges, index)
             if translatable:
-                original = "\n".join(
-                    lines[translatable.start: translatable.end])
-                output.extend(self._split_translation_unit(
-                    original, max_line_length))
+                original = "\n".join(lines[translatable.start : translatable.end])
+                protected_original = self._protect_inline_markdown(
+                    original, placeholder_map
+                )
+                output.extend(
+                    self._split_translation_unit(protected_original, max_line_length)
+                )
                 index = translatable.end
                 continue
 

--- a/develop_requirements.txt
+++ b/develop_requirements.txt
@@ -4,3 +4,4 @@ ruff
 black
 autopep8
 ipykernel
+markdown-it-py

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 PyGithub
 deep_translator
+markdown-it-py

--- a/tests/fixtures/github_markdown.md
+++ b/tests/fixtures/github_markdown.md
@@ -1,0 +1,34 @@
+---
+title: GitHub Markdown sample
+---
+
+# GitHub Flavored Markdown fixture
+
+> [!WARNING]
+> Inline code such as `FILES` must remain exact while this description is translated.
+> Links like [the project README](../README.md) should keep their target URL.
+
+- `FILES`: A comma-separated list of files to translate.
+- Use `LANGS` to define target languages.
+- [ ] Keep task-list syntax intact.
+- [x] Keep checked task-list syntax intact.
+
+| Input | Meaning |
+| --- | --- |
+| `LANGS` | Languages to generate |
+
+```yml
+FILES: README.md
+LANGS: russian,english
+```
+
+<details>
+<summary>Expandable section</summary>
+
+Text inside details can be translated.
+
+</details>
+
+<div align="center">
+  <img src="https://example.com/badge.svg" alt="Badge">
+</div>

--- a/tests/test_localizator.py
+++ b/tests/test_localizator.py
@@ -47,12 +47,36 @@ class LocalizationManagerTests(unittest.IsolatedAsyncioTestCase):
         _, _, thread_name = BlockingTranslator.calls[0]
         self.assertNotEqual(thread_name, threading.current_thread().name)
 
+    async def test_translate_markdown_unit_preserves_inline_placeholders(self):
+        manager = LocalizationManager(langs="ru", files=[], max_threads=1)
+        try:
+            manager.processor.placeholder_map["_NON_TRANSLATE"] = [
+                ("_NON_TRANSLATE_token", "`FILES`")
+            ]
+
+            with patch("core.app.localizator.GoogleTranslator", BlockingTranslator):
+                translated = await manager.translate_markdown_unit(
+                    "- _NON_TRANSLATE_token: A comma-separated list", "ru"
+                )
+        finally:
+            manager.shutdown()
+
+        self.assertEqual(
+            translated, "- _NON_TRANSLATE_tokenru:: A comma-separated list"
+        )
+        translated_segments = [call[1] for call in BlockingTranslator.calls]
+        self.assertEqual(translated_segments, [": A comma-separated list"])
+
     async def test_translate_text_uses_cache(self):
         manager = LocalizationManager(langs="es", files=[], max_threads=1)
         try:
             with patch("core.app.localizator.GoogleTranslator", BlockingTranslator):
-                self.assertEqual(await manager.translate_text("hello", "es"), "es:hello")
-                self.assertEqual(await manager.translate_text("hello", "es"), "es:hello")
+                self.assertEqual(
+                    await manager.translate_text("hello", "es"), "es:hello"
+                )
+                self.assertEqual(
+                    await manager.translate_text("hello", "es"), "es:hello"
+                )
         finally:
             manager.shutdown()
 

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,0 +1,72 @@
+import unittest
+
+from core.app.processor import Processor
+
+
+class ProcessorAstTests(unittest.TestCase):
+    def test_preserves_fenced_code_as_single_placeholder(self):
+        content = "# Title\n\n```python\nfor line in lines:\n    print(line)\n```\n\nParagraph text."
+        processor = Processor()
+
+        units, placeholder_map = processor.decompile_file(content, file="README.md")
+
+        self.assertIn("# Title", units)
+        self.assertIn("Paragraph text.", units)
+        self.assertEqual(len(placeholder_map["_MD_PROTECTED"]), 1)
+        placeholder, original = placeholder_map["_MD_PROTECTED"][0]
+        self.assertIn(placeholder, units)
+        self.assertEqual(
+            original, "```python\nfor line in lines:\n    print(line)\n```"
+        )
+
+        rebuilt = processor.build_file(units, placeholder_map, "es", file="README.md")
+        self.assertEqual(rebuilt, content)
+
+    def test_preserves_frontmatter_tables_html_mdx_and_selected_admonitions(self):
+        content = "\n".join(
+            [
+                "---",
+                "title: Docs",
+                "---",
+                "",
+                "import Chart from './Chart'",
+                "",
+                "| Name | Value |",
+                "| --- | --- |",
+                "| A | B |",
+                "",
+                "> [!IMPORTANT]",
+                "> Keep this exact.",
+                "",
+                "<div>",
+                "  <span>Raw HTML</span>",
+                "</div>",
+                "",
+                "Regular paragraph",
+            ]
+        )
+        processor = Processor()
+
+        units, placeholder_map = processor.decompile_file(content, file="README.md")
+
+        self.assertIn("Regular paragraph", units)
+        protected = [original for _, original in placeholder_map["_MD_PROTECTED"]]
+        notes = [original for _, original in placeholder_map["_MD_BLOCK_NOTE"]]
+        self.assertIn("---\ntitle: Docs\n---", protected)
+        self.assertIn("import Chart from './Chart'", protected)
+        self.assertIn("| Name | Value |\n| --- | --- |\n| A | B |", protected)
+        self.assertIn("<div>\n  <span>Raw HTML</span>\n</div>", protected)
+        self.assertEqual(notes, ["> [!IMPORTANT]\n> Keep this exact."])
+        self.assertEqual(processor.build_file(units, placeholder_map, "es"), content)
+
+    def test_multiline_list_item_is_single_translation_unit(self):
+        content = "- first line\n  continuation line\n  - nested item"
+        processor = Processor()
+
+        units, _ = processor.decompile_file(content)
+
+        self.assertEqual(units, [content])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_processor.py
+++ b/tests/test_processor.py
@@ -1,4 +1,5 @@
 import unittest
+from pathlib import Path
 
 from core.app.processor import Processor
 
@@ -56,8 +57,62 @@ class ProcessorAstTests(unittest.TestCase):
         self.assertIn("import Chart from './Chart'", protected)
         self.assertIn("| Name | Value |\n| --- | --- |\n| A | B |", protected)
         self.assertIn("<div>\n  <span>Raw HTML</span>\n</div>", protected)
-        self.assertEqual(notes, ["> [!IMPORTANT]\n> Keep this exact."])
+        self.assertEqual(notes, ["> [!IMPORTANT]"])
+        self.assertIn("> Keep this exact.", units)
         self.assertEqual(processor.build_file(units, placeholder_map, "es"), content)
+
+    def test_admonition_marker_is_protected_but_body_is_translatable(self):
+        content = (
+            "> [!WARNING]\n"
+            "> We only use TRANSLATION DeepL\n"
+            "> This may affect the quality of the translation."
+        )
+        processor = Processor()
+
+        units, placeholder_map = processor.decompile_file(content, file="README.md")
+
+        notes = [original for _, original in placeholder_map["_MD_BLOCK_NOTE"]]
+        self.assertEqual(notes, ["> [!WARNING]"])
+        self.assertIn(
+            "> We only use TRANSLATION DeepL\n"
+            "> This may affect the quality of the translation.",
+            units,
+        )
+        self.assertEqual(processor.build_file(units, placeholder_map, "ru"), content)
+
+    def test_inline_code_is_protected_inside_translatable_text(self):
+        content = "- `FILES`: A comma-separated list of files to translate."
+        processor = Processor()
+
+        units, placeholder_map = processor.decompile_file(content, file="README.md")
+
+        protected_inline = [
+            original for _, original in placeholder_map["_NON_TRANSLATE"]
+        ]
+        self.assertEqual(protected_inline, ["`FILES`"])
+        self.assertNotIn("`FILES`", units[0])
+        self.assertEqual(processor.build_file(units, placeholder_map, "ru"), content)
+
+    def test_github_markdown_fixture_keeps_admonition_body_and_inline_code_safe(self):
+        content = Path("tests/fixtures/github_markdown.md").read_text(encoding="utf-8")
+        processor = Processor()
+
+        units, placeholder_map = processor.decompile_file(
+            content, file="github_markdown.md"
+        )
+
+        notes = [original for _, original in placeholder_map["_MD_BLOCK_NOTE"]]
+        inline = [original for _, original in placeholder_map["_NON_TRANSLATE"]]
+        self.assertEqual(notes, ["> [!WARNING]"])
+        self.assertTrue(
+            any("Inline code such as" in unit for unit in units),
+            "Admonition body should remain in translatable units.",
+        )
+        self.assertIn("`FILES`", inline)
+        links = [original for _, original in placeholder_map["_L1NK"]]
+        self.assertIn("`LANGS`", inline)
+        self.assertIn("../README.md", links)
+        self.assertEqual(processor.build_file(units, placeholder_map, "ru"), content)
 
     def test_multiline_list_item_is_single_translation_unit(self):
         content = "- first line\n  continuation line\n  - nested item"


### PR DESCRIPTION
## Изменения: 
- Переход Processor с regex/placeholders на Markdown token/range pipeline. 
- Структурная защита для frontmatter, fenced/code/html/table blocks, MDX import/export/component lines и admonitions. 
- Группировка Markdown units по AST/token ranges для paragraph/heading/list item, включая multiline/nested list blocks, с восстановлением protected placeholders при сборке файла.

ну и тесты frontmatter/tables/html/mdx/admonitions // multiline nested list translation unit